### PR TITLE
Fix behavior when patch removes null uneditable fields

### DIFF
--- a/scim2_server/operators.py
+++ b/scim2_server/operators.py
@@ -258,15 +258,16 @@ class RemoveOperator(Operator):
     @classmethod
     def operation(cls, model: BaseModel, attribute: str, value: Any):
         alias = get_by_alias(type(model), attribute)
-        existing_value = getattr(model, alias)
-        if not existing_value:
-            return
 
         if model.get_field_annotation(alias, Mutability) in (
             Mutability.read_only,
             Mutability.immutable,
         ):
             raise SCIMException(Error.make_mutability_error())
+
+        existing_value = getattr(model, alias)
+        if not existing_value:
+            return
 
         if model.get_field_annotation(alias, Required) == Required.true:
             raise SCIMException(Error.make_invalid_value_error())

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -451,6 +451,16 @@ class TestOperators:
         with pytest.raises(SCIMException, match="immutable"):
             RemoveOperator.operation(u, "groups", None)
 
+    def test_remove_operator_mutability_validation_on_empty_fields(self):
+        """Test that mutability constraints are enforced even on empty/unset fields."""
+        u = User(id="123")  # groups field is None/empty by default
+        with pytest.raises(SCIMException, match="mutability"):
+            RemoveOperator.operation(u, "groups", None)
+
+        u2 = User()  # id field is None/empty by default
+        with pytest.raises(SCIMException, match="mutability"):
+            RemoveOperator.operation(u2, "id", None)
+
     def test_remove_operator_root_object(self):
         u = User()
         with pytest.raises(SCIMException, match="noTarget"):


### PR DESCRIPTION
A mutability error should be raised when deleting read only and immutable fields, even if they are empty in the first place.